### PR TITLE
chore: pin trivy github action to v0.35.0

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -21,7 +21,7 @@ jobs:
           docker build -t ${IMAGE} .
           echo "image=$IMAGE" >> $GITHUB_OUTPUT
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@m57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ steps.build.outputs.image }}
           format: table


### PR DESCRIPTION
Changed cve-scan.yaml workflow to pin trivy to the SHA corresponding to v0.35.0 rather than just using "master'.